### PR TITLE
First implementation bits (long-running PR)

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,6 +13,11 @@ jobs:
         uses: actions/checkout@v3.3.0
       - name: ormolu
         uses: mrkkrp/ormolu-action@v11
+        with:
+          pattern: |
+            **/*.hs
+            **/*.hs-boot
+            !troupe/troupe-distributed-process/Control/Distributed/Process/Internal/*.hs
 
   cabal-fmt:
     name: Lint Cabal project description using cabal-fmt

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -166,6 +166,8 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           constraints: troupe +werror
+          allow-newer: focus-1.0.3:transformers
+          allow-newer: stm-hamt-1.2.0.9:transformers
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(troupe)$/; }' >> cabal.project.local
           cat cabal.project
@@ -196,6 +198,7 @@ jobs:
       - name: hlint
         run: |
           if [ $((HCNUMVER < 90600)) -ne 0 ] ; then (cd ${PKGDIR_troupe} && hlint -XHaskell2010 src) ; fi
+          if [ $((HCNUMVER < 90600)) -ne 0 ] ; then (cd ${PKGDIR_troupe} && hlint -XHaskell2010 troupe-distributed-process) ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_troupe} || false

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,2 +1,5 @@
+-- Need `Allow-Newer` for GHC-9.6 (for now)
+Copy-Fields: some
+
 Hlint: True
 Hlint-Job: 9.4.4

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,9 @@
 Packages:
   troupe
 
+Allow-Newer:
+  focus-1.0.3:transformers,
+  stm-hamt-1.2.0.9:transformers,
+
 Constraints:
   troupe +werror,

--- a/troupe/.hlint.yaml
+++ b/troupe/.hlint.yaml
@@ -1,0 +1,6 @@
+# Ignore vendored code
+- ignore:
+    within: [ "Control.Distributed.Process.Internal.CQueue",
+              "Control.Distributed.Process.Internal.StrictList",
+              "Control.Distributed.Process.Internal.StrictMVar",
+            ]

--- a/troupe/src/MyLib.hs
+++ b/troupe/src/MyLib.hs
@@ -1,6 +1,0 @@
--- | My library.
-module MyLib (someFunc) where
-
--- | Some function.
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"

--- a/troupe/src/Troupe.hs
+++ b/troupe/src/Troupe.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Core functionality of the @troupe@ library.
+module Troupe
+  ( -- * Main entrypoint
+    runNode,
+
+    -- * Processes
+    Process,
+    ProcessId,
+
+    -- ** Spawning processes
+    spawn,
+    spawnLink,
+    spawnMonitor,
+
+    -- ** Exchanging messages between processes
+    send,
+    sendLazy,
+    receive,
+    receiveTimeout,
+    expect,
+    Match,
+    match,
+    matchIf,
+
+    -- ** Linking and monitoring processes
+    link,
+    unlink,
+    MonitorRef,
+    monitor,
+    DemonitorOption (..),
+    demonitor,
+
+    -- ** Querying the process table
+    isProcessAlive,
+
+    -- ** Killing processes
+    exit,
+
+    -- ** Process-local actions
+    self,
+    ProcessOption (..),
+    setProcessOption,
+    getProcessOption,
+
+    -- * Built-in messages and signals
+    NoProc (..),
+    isNoProc,
+    pattern IsNoProc,
+    InvalidMonitorRef (..),
+    isInvalidMonitorRef,
+    pattern IsInvalidMonitorRef,
+    Down (..),
+    Exit (..),
+    isExit,
+    pattern IsExit,
+    kill,
+    Killed (..),
+    isKilled,
+    pattern IsKilled,
+
+    -- * @mtl@-style transformer support
+    MonadProcess (..),
+  )
+where
+
+import Control.Concurrent.STM (atomically, check)
+import qualified StmContainers.Map as Map
+import Troupe.Exceptions
+  ( Exit (..),
+    InvalidMonitorRef (..),
+    Killed (..),
+    NoProc (..),
+    isExit,
+    isInvalidMonitorRef,
+    isKilled,
+    isNoProc,
+    kill,
+    pattern IsExit,
+    pattern IsInvalidMonitorRef,
+    pattern IsKilled,
+    pattern IsNoProc,
+  )
+import Troupe.Process
+  ( DemonitorOption (..),
+    Match,
+    MonadProcess (..),
+    NodeContext (..),
+    Process,
+    ProcessEnv (..),
+    ProcessOption (..),
+    demonitor,
+    exit,
+    expect,
+    getProcessOption,
+    isProcessAlive,
+    link,
+    match,
+    matchIf,
+    monitor,
+    newNodeContext,
+    newProcessContext,
+    receive,
+    receiveTimeout,
+    runProcess,
+    self,
+    send,
+    sendLazy,
+    setProcessOption,
+    spawn,
+    spawnLink,
+    spawnMonitor,
+    unlink,
+  )
+import Troupe.Types (Down (..), MonitorRef, ProcessId)
+
+-- | Main entrypoint to launch a root 'Process'
+--
+-- This will run the given 'Process', with the given @r@ available in
+-- the 'Control.Monad.Reader.Class.MonadReader' environment of this 'Process',
+-- or any 'Process' spawned from it (and so on).
+--
+-- This blocks as long as some 'Process' is running, hence, @runNode r p@
+-- doesn't necessarily return when @p@ returns.
+runNode :: r -> Process r a -> IO ()
+runNode r process = do
+  nodeContext <- newNodeContext r
+  processContext <- newProcessContext nodeContext
+  let processEnv = ProcessEnv nodeContext processContext
+
+  _ <- runProcess (spawn process) processEnv
+
+  atomically $ do
+    cnt <- Map.size (nodeContextProcesses nodeContext)
+    check (cnt == 0)
+
+{-
+-- alias
+-- cancel_timer
+-- group_leader?
+-- halt
+-- hibernate?
+-- make_ref ?
+-- monitor/3
+-- process_flag/3
+-- process_info
+-- processes
+-- read_timer
+-- register
+-- registered
+-- resume_process
+-- send_after
+-- send_nosuspend
+-- ...
+
+-}

--- a/troupe/src/Troupe/Exceptions.hs
+++ b/troupe/src/Troupe/Exceptions.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
+module Troupe.Exceptions
+  ( NoProc (..),
+    isNoProc,
+    pattern IsNoProc,
+    InvalidMonitorRef (..),
+    isInvalidMonitorRef,
+    pattern IsInvalidMonitorRef,
+    Exit (..),
+    isExit,
+    pattern IsExit,
+    Kill (..),
+    isKill,
+    kill,
+    Killed (..),
+    isKilled,
+    pattern IsKilled,
+  )
+where
+
+import Control.DeepSeq (NFData (..), ($!!))
+import Control.Exception.Base
+  ( Exception (..),
+    SomeException,
+    asyncExceptionFromException,
+    asyncExceptionToException,
+  )
+import GHC.Generics (Generic)
+import Troupe.Types (MonitorRef, ProcessId)
+
+-- | Exception delivered when a non-existing 'ProcessId' is used.
+newtype NoProc = NoProc ProcessId
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (NFData)
+
+instance Exception NoProc where
+  fromException = asyncExceptionFromException
+  toException = asyncExceptionToException
+  displayException (NoProc pid) = "No such process: " <> show pid
+
+-- | Predicate on 'NoProc' exceptions.
+isNoProc :: SomeException -> Bool
+isNoProc exc = case fromException exc of
+  Just NoProc {} -> True
+  Nothing -> False
+
+-- | Pattern match on 'NoProc' exceptions from 'SomeException'.
+pattern IsNoProc :: ProcessId -> SomeException
+pattern IsNoProc pid <- (fromException -> Just (NoProc pid))
+
+-- | Exception delivered when an invalid 'MonitorRef' is used, e.g.,
+-- when 'Troupe.demonitor'ing a 'MonitorRef' owned by another process.
+newtype InvalidMonitorRef = InvalidMonitorRef MonitorRef
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (NFData)
+
+instance Exception InvalidMonitorRef where
+  fromException = asyncExceptionFromException
+  toException = asyncExceptionToException
+  displayException (InvalidMonitorRef ref) = "Invalid MonitorRef: " <> show ref
+
+-- | Predicate on 'InvalidMonitorRef' exceptions.
+isInvalidMonitorRef :: SomeException -> Bool
+isInvalidMonitorRef exc = case fromException exc of
+  Just InvalidMonitorRef {} -> True
+  Nothing -> False
+
+-- | Pattern match on 'InvalidMonitorRef' exceptions from 'SomeException'.
+pattern IsInvalidMonitorRef :: MonitorRef -> SomeException
+pattern IsInvalidMonitorRef ref <- (fromException -> Just (InvalidMonitorRef ref))
+
+-- | Exception raised when a 'Troupe.link'ed process stops (either successfully
+-- or with some exception), or delivered as a message when 'Troupe.TrapExit' is
+-- set for the receiving process.
+data Exit = Exit
+  { -- | 'ProcessId' of the process which stopped.
+    exitSender :: {-# UNPACK #-} !ProcessId,
+    -- | 'ProcessId' of the process to which this message or signal is delivered.
+    exitReceiver :: {-# UNPACK #-} !ProcessId,
+    -- | This message or signal is delivered because of a 'Troupe.link' between
+    -- both processes.
+    exitLink :: !Bool,
+    -- | Reason for the process to stop. 'Nothing' if successful, @'Just' e@ when
+    -- stopped with some exception.
+    exitReason :: !(Maybe SomeException)
+  }
+  deriving (Show)
+
+instance Exception Exit where
+  fromException = asyncExceptionFromException
+  toException = asyncExceptionToException
+
+-- | Predicate on 'Exit' exceptions.
+isExit :: SomeException -> Bool
+isExit exc = case fromException exc of
+  Just Exit {} -> True
+  Nothing -> False
+
+-- | Pattern match on 'Exit' exceptions from 'SomeException'.
+pattern IsExit ::
+  -- | 'ProcessId' of the process which stopped.
+  ProcessId ->
+  -- | 'ProcessId' of the process to which this message or signal is delivered.
+  ProcessId ->
+  -- | This message or signal is delivered because of a 'Troupe.link' between
+  -- both processes.
+  Bool ->
+  -- | Reason for the process to stop. 'Nothing' if successful, @'Just' e@ when
+  -- stopped with some exception.
+  Maybe SomeException ->
+  SomeException
+pattern IsExit sender receiver link reason <- (fromException -> Just (Exit sender receiver link reason))
+
+-- | Exception raised to forcibly kill a process.
+--
+-- Since the type is not exported (from "Troupe"), there's no way to match
+-- on it, and hence catch it (except when catching 'SomeException', which
+-- should be avoided).
+newtype Kill = Kill String
+  deriving (Show, Eq)
+
+instance Exception Kill where
+  fromException = asyncExceptionFromException
+  toException = asyncExceptionToException
+  displayException (Kill msg) = "Kill: " <> msg
+
+instance NFData Kill where
+  rnf (Kill msg) = rnf msg
+
+isKill :: SomeException -> Bool
+isKill exc = case fromException exc of
+  Just Kill {} -> True
+  Nothing -> False
+
+-- | Construct a 'Kill' exception given some message.
+--
+-- This exception can't be caught inside a process (unless catching
+-- 'SomeException'), hence, @'Troupe.exit' pid (Just $ 'kill' message)@
+-- will effectively cause a process to exit. Linked processes and monitors
+-- are notified of this using the standard mechanisms, with one caveat:
+-- a 'Kill' exception is transformed into a 'Killed' exception (as found
+-- in, e.g., 'Troupe.Types.downReason' or 'exitReason') so it can be caught
+-- in linked or monitoring processes.
+kill :: String -> SomeException
+kill !msg = toException $!! Kill msg
+
+-- | Exception used to inform links and monitors of a 'Kill' exception raised
+-- by some linked or monitored process.
+--
+-- See 'kill'.
+newtype Killed = Killed String
+  deriving (Show, Eq, Generic)
+  deriving anyclass (NFData)
+
+instance Exception Killed where
+  displayException (Killed msg) = "Killed: " <> msg
+
+-- | Predicate on 'Killed' exceptions.
+isKilled :: SomeException -> Bool
+isKilled exc = case fromException exc of
+  Just Killed {} -> True
+  Nothing -> False
+
+-- | Pattern match on 'Killed' exceptions from 'SomeException'.
+pattern IsKilled :: String -> SomeException
+pattern IsKilled msg <- (fromException -> Just (Killed msg))

--- a/troupe/src/Troupe/Process.hs
+++ b/troupe/src/Troupe/Process.hs
@@ -1,0 +1,845 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
+module Troupe.Process
+  ( NodeContext (..),
+    newNodeContext,
+    newProcessContext,
+    ProcessEnv (..),
+    MonadProcess (..),
+    Process,
+    runProcess,
+    self,
+    ProcessOption (..),
+    setProcessOption,
+    getProcessOption,
+    link,
+    unlink,
+    monitor,
+    DemonitorOption (..),
+    demonitor,
+    exit,
+    isProcessAlive,
+    spawn,
+    spawnLink,
+    spawnMonitor,
+    send,
+    sendLazy,
+    receive,
+    receiveTimeout,
+    expect,
+    Match,
+    match,
+    matchIf,
+  )
+where
+
+import Control.Applicative (Alternative, (<|>))
+import Control.Concurrent.Async (async, cancelWith, uninterruptibleCancel, waitCatchSTM, withAsyncWithUnmask)
+import Control.Concurrent.STM
+  ( STM,
+    TQueue,
+    TVar,
+    atomically,
+    newEmptyTMVarIO,
+    newTQueue,
+    newTVar,
+    newTVarIO,
+    readTMVar,
+    readTQueue,
+    readTVar,
+    throwSTM,
+    tryReadTMVar,
+    writeTMVar,
+    writeTQueue,
+    writeTVar,
+  )
+import Control.DeepSeq (NFData, deepseq, ($!!))
+import Control.Distributed.Process.Internal.CQueue
+  ( BlockSpec (..),
+    CQueue,
+    MatchOn (MatchMsg),
+    dequeue,
+    enqueueSTM,
+    newCQueue,
+  )
+import Control.Exception.Safe
+  ( Exception (..),
+    IOException,
+    MonadCatch,
+    MonadMask,
+    MonadThrow,
+    SomeException,
+    bracketOnError,
+    finally,
+    mask_,
+    throwM,
+    toException,
+    uninterruptibleMask_,
+    withException,
+  )
+import Control.Monad (MonadPlus, unless, void, when)
+import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Fix (MonadFix)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Primitive (PrimMonad)
+import Control.Monad.Random.Class (MonadRandom, MonadSplit)
+import Control.Monad.Reader.Class (MonadReader (..))
+import Control.Monad.Time (MonadTime)
+import Control.Monad.Trans (MonadTrans, lift)
+import Control.Monad.Trans.Accum (AccumT)
+import Control.Monad.Trans.Cont (ContT)
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Identity (IdentityT)
+import Control.Monad.Trans.Maybe (MaybeT)
+import qualified Control.Monad.Trans.RWS.CPS as CPS (RWST)
+import qualified Control.Monad.Trans.RWS.Lazy as Lazy (RWST)
+import qualified Control.Monad.Trans.RWS.Strict as Strict (RWST)
+import qualified Control.Monad.Trans.Random.Lazy as Lazy (RandT)
+import qualified Control.Monad.Trans.Random.Strict as Strict (RandT)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT, withReaderT)
+import Control.Monad.Trans.Select (SelectT)
+import qualified Control.Monad.Trans.State.Lazy as Lazy (StateT)
+import qualified Control.Monad.Trans.State.Strict as Strict (StateT)
+import qualified Control.Monad.Trans.Writer.CPS as CPS (WriterT)
+import qualified Control.Monad.Trans.Writer.Lazy as Lazy (WriterT)
+import qualified Control.Monad.Trans.Writer.Strict as Strict (WriterT)
+import Data.Dynamic (Dynamic, fromDynamic, toDyn)
+import Data.Functor.Identity (Identity (..), runIdentity)
+import Data.Maybe (isJust)
+import Data.Typeable (Typeable)
+import DeferredFolds.UnfoldlM (forM_)
+import StmContainers.Map (Map)
+import qualified StmContainers.Map as Map
+import StmContainers.Set (Set)
+import qualified StmContainers.Set as Set
+import System.Random (StdGen)
+import System.Random.Stateful (AtomicGenM, IOGenM, RandomGenM)
+import Troupe.Exceptions (Exit (..), InvalidMonitorRef (..), Kill (..), Killed (..), NoProc (..), isKill)
+import Troupe.Types
+  ( Down (..),
+    MonitorRef (..),
+    MonitorRefId,
+    ProcessId,
+    monitorRefId0,
+    processId0,
+    succMonitorRefId,
+    succProcessId,
+  )
+
+data NodeContext r = NodeContext
+  { nodeContextNextProcessId :: {-# UNPACK #-} !(TVar ProcessId),
+    nodeContextNextMonitorRefId :: {-# UNPACK #-} !(TVar MonitorRefId),
+    nodeContextProcesses :: {-# UNPACK #-} !(Map ProcessId ProcessContext),
+    nodeContextR :: r
+  }
+
+newNodeContext :: r -> IO (NodeContext r)
+newNodeContext r =
+  NodeContext
+    <$> newTVarIO processId0
+    <*> newTVarIO monitorRefId0
+    <*> Map.newIO
+    <*> pure r
+
+data ProcessContext = ProcessContext
+  { processContextId :: {-# UNPACK #-} !ProcessId,
+    processContextQueue :: {-# UNPACK #-} !(CQueue Dynamic),
+    processContextExceptions :: {-# UNPACK #-} !(TQueue SomeException),
+    processContextTrapExit :: {-# UNPACK #-} !(TVar Bool),
+    processContextLinks :: {-# UNPACK #-} !(Set ProcessId),
+    processContextMonitors :: {-# UNPACK #-} !(Set MonitorRef),
+    processContextMonitorees :: {-# UNPACK #-} !(Set MonitorRef)
+  }
+
+newProcessContextSTM :: CQueue Dynamic -> ReaderT (NodeContext r) STM ProcessContext
+newProcessContextSTM queue = do
+  pid <- newPid
+  lift $
+    ProcessContext pid queue
+      <$> newTQueue
+      <*> newTVar False
+      <*> Set.new
+      <*> Set.new
+      <*> Set.new
+  where
+    newPid = do
+      curr <- readTVarR nodeContextNextProcessId
+      writeTVarR nodeContextNextProcessId $!! succProcessId curr
+      pure curr
+
+newProcessContext :: NodeContext r -> IO ProcessContext
+newProcessContext nodeContext = do
+  queue <- newCQueue
+  atomically $ runReaderT (newProcessContextSTM queue) nodeContext
+
+data ProcessEnv r = ProcessEnv
+  { processEnvNodeContext :: {-# UNPACK #-} !(NodeContext r),
+    processEnvProcessContext :: {-# UNPACK #-} !ProcessContext
+  }
+
+-- | @mtl@-style class to bring 'Process' support to transformers.
+class (Monad m) => MonadProcess r m | m -> r where
+  -- | Get the 'ProcessEnv'. This can't be implemented outside of the @troupe@
+  -- library, so any transformer should just 'lift' the action, as the default
+  -- implementation does.
+  getProcessEnv :: m (ProcessEnv r)
+  default getProcessEnv :: (MonadProcess r n, MonadTrans t, m ~ t n) => m (ProcessEnv r)
+  getProcessEnv = lift getProcessEnv
+
+instance (MonadProcess r m, Monoid w) => MonadProcess r (AccumT w m)
+
+instance (MonadProcess r m) => MonadProcess r (ContT r m)
+
+instance (MonadProcess r m) => MonadProcess r (ExceptT e m)
+
+instance (MonadProcess r m) => MonadProcess r (IdentityT m)
+
+instance (MonadProcess r m) => MonadProcess r (MaybeT m)
+
+instance (MonadProcess r m) => MonadProcess r (CPS.RWST r w s m)
+
+instance (MonadProcess r m, Monoid w) => MonadProcess r (Lazy.RWST r w s m)
+
+instance (MonadProcess r m, Monoid w) => MonadProcess r (Strict.RWST r w s m)
+
+instance (MonadProcess r m) => MonadProcess r (ReaderT t m)
+
+instance (MonadProcess r m) => MonadProcess r (SelectT s m)
+
+instance (MonadProcess r m) => MonadProcess r (Lazy.StateT s m)
+
+instance (MonadProcess r m) => MonadProcess r (Strict.StateT s m)
+
+instance (MonadProcess r m) => MonadProcess r (CPS.WriterT w m)
+
+instance (MonadProcess r m, Monoid w) => MonadProcess r (Lazy.WriterT w m)
+
+instance (MonadProcess r m, Monoid w) => MonadProcess r (Strict.WriterT w m)
+
+instance (MonadProcess r m) => MonadProcess r (Lazy.RandT g m)
+
+instance (MonadProcess r m) => MonadProcess r (Strict.RandT g m)
+
+-- | Base monad for any process.
+--
+-- The @r@ type variable defines the type of the 'MonadReader' context that
+-- will be available in the 'Process', and any 'Process' spawned from it.
+newtype Process r a = Process {unProcess :: ReaderT (ProcessEnv r) IO a}
+  deriving newtype
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadFail,
+      MonadFix,
+      MonadIO,
+      MonadPlus,
+      Alternative,
+      MonadError IOException,
+      MonadThrow,
+      MonadCatch,
+      MonadMask,
+      MonadRandom,
+      MonadSplit StdGen,
+      RandomGenM (IOGenM s) s,
+      RandomGenM (AtomicGenM s) s,
+      MonadTime,
+      PrimMonad
+    )
+
+instance MonadProcess r (Process r) where
+  getProcessEnv = Process ask
+  {-# INLINE getProcessEnv #-}
+
+instance MonadReader r (Process r) where
+  ask = Process $ reader (nodeContextR . processEnvNodeContext)
+  reader f = Process $ reader (f . nodeContextR . processEnvNodeContext)
+  local f (Process a) = Process $ local mapR a
+    where
+      mapR env =
+        env
+          { processEnvNodeContext =
+              (processEnvNodeContext env)
+                { nodeContextR = f (nodeContextR (processEnvNodeContext env))
+                }
+          }
+
+runProcess :: Process r a -> ProcessEnv r -> IO a
+runProcess = runReaderT . unProcess
+
+-- | Get the 'ProcessId' of the running process.
+self :: (MonadProcess r m) => m ProcessId
+self = processContextId . processEnvProcessContext <$> getProcessEnv
+{-# INLINE self #-}
+{-# SPECIALIZE self :: Process r ProcessId #-}
+
+writeTVarR :: (r -> TVar a) -> a -> ReaderT r STM ()
+writeTVarR g a = reader g >>= \v -> lift (writeTVar v a)
+{-# INLINE writeTVarR #-}
+
+readTVarR :: (r -> TVar a) -> ReaderT r STM a
+readTVarR g = reader g >>= \v -> lift (readTVar v)
+{-# INLINE readTVarR #-}
+
+liftMonadProcess :: (MonadProcess r m, MonadIO m) => (ProcessEnv r -> s) -> ReaderT s STM a -> m a
+liftMonadProcess fn act = getProcessEnv >>= \e -> liftIO $ atomically $ runReaderT act (fn e)
+{-# INLINE liftMonadProcess #-}
+
+-- | Options that can change behaviour of a process.
+--
+-- The type argument defines the type of the option.
+--
+-- See 'setProcessOption' and 'getProcessOption'.
+data ProcessOption t where
+  -- | When a 'link'ed process stops, notify the process by sending an 'Exit'
+  -- message to its mailbox, instead of killing it (if the 'link'ed process
+  -- exited with an exception).
+  TrapExit :: ProcessOption Bool
+
+setProcessOptionSTM :: ProcessOption t -> t -> ReaderT ProcessContext STM ()
+setProcessOptionSTM !option !t = case option of
+  TrapExit -> writeTVarR processContextTrapExit $!! t
+
+-- | Set a 'ProcessOption' setting, returning the previous value.
+setProcessOption :: (MonadProcess r m, MonadIO m) => ProcessOption t -> t -> m t
+setProcessOption option t = do
+  env <- processEnvProcessContext <$> getProcessEnv
+  liftIO $ atomically $ flip runReaderT env $ do
+    curr <- getProcessOptionSTM option
+    setProcessOptionSTM option t
+    pure curr
+{-# SPECIALIZE setProcessOption :: ProcessOption t -> t -> Process r t #-}
+
+getProcessOptionSTM :: ProcessOption t -> ReaderT ProcessContext STM t
+getProcessOptionSTM !option = case option of
+  TrapExit -> readTVarR processContextTrapExit
+
+-- | Get a 'ProcessOption' setting.
+getProcessOption :: (MonadProcess r m, MonadIO m) => ProcessOption t -> m t
+getProcessOption = liftMonadProcess processEnvProcessContext . getProcessOptionSTM
+{-# SPECIALIZE getProcessOption :: ProcessOption t -> Process r t #-}
+
+sendLazySTM :: (Typeable a) => ProcessContext -> a -> STM ()
+sendLazySTM !pc !a = enqueueSTM (processContextQueue pc) (toDyn a)
+
+deliverException :: ProcessContext -> SomeException -> STM ()
+deliverException !pc !exc = writeTQueue (processContextExceptions pc) exc
+
+convertKillToKilled :: SomeException -> SomeException
+convertKillToKilled exc = case fromException exc of
+  Just (Kill msg) -> toException $ Killed msg
+  Nothing -> exc
+
+deliverExit :: ProcessContext -> Exit -> STM ()
+deliverExit !pc !exc = do
+  let exc' = exc {exitReason = fmap convertKillToKilled (exitReason exc)}
+  readTVar (processContextTrapExit pc) >>= \case
+    True -> sendLazySTM pc exc'
+    False -> case exitReason exc' of
+      Nothing -> pure () -- Process exited without exception
+      Just _ -> deliverException pc (toException exc')
+
+lookupProcess :: ProcessId -> ReaderT (NodeContext r) STM (Maybe ProcessContext)
+lookupProcess !pid = reader nodeContextProcesses >>= lift . Map.lookup pid
+
+linkSTM :: ProcessId -> ReaderT (ProcessEnv r) STM ()
+linkSTM !pid = do
+  thisProcess <- reader processEnvProcessContext
+  -- Linking to yourself is a no-op
+  unless (pid == processContextId thisProcess) $ do
+    withReaderT processEnvNodeContext (lookupProcess pid) >>= \case
+      Nothing -> lift $ do
+        let exc = Exit pid (processContextId thisProcess) True (Just $ toException $ NoProc pid)
+        deliverExit thisProcess exc
+      Just pc -> lift $ do
+        Set.insert (processContextId thisProcess) (processContextLinks pc)
+        Set.insert pid (processContextLinks thisProcess)
+
+-- | Link the current process to another one.
+--
+-- Links are bidirectional.
+--
+-- If 'TrapExit' is not set (the default), and a 'link'ed process stops with
+-- an exception, the other end of the link will receive an 'Exit' signal and
+-- hence stop as well. When a 'link'ed process stops without an exception,
+-- nothing happens.
+--
+-- If 'TrapExit' is set, and a 'link'ed process stops, an 'Exit' message is
+-- delivered to the 'link'ed process' mailbox.
+link :: (MonadProcess r m, MonadIO m) => ProcessId -> m ()
+link = liftMonadProcess id . linkSTM
+{-# SPECIALIZE link :: ProcessId -> Process r () #-}
+
+unlinkSTM :: ProcessId -> ReaderT (ProcessEnv r) STM ()
+unlinkSTM !pid =
+  withReaderT processEnvNodeContext (lookupProcess pid) >>= \case
+    Nothing -> do
+      -- If all is good, the pid is not in our local links set since
+      -- either no link to the PID was ever created (`linkSTM` delivered
+      -- an error), or the PID is dead and hence, the link was removed
+      -- already.
+      -- Since we can't discern between the two cases, there's no invariant
+      -- to check here.
+      pure ()
+    Just pc -> do
+      thisProcess <- reader processEnvProcessContext
+      lift $ do
+        Set.delete (processContextId thisProcess) (processContextLinks pc)
+        Set.delete pid (processContextLinks thisProcess)
+
+-- | Unlink the current process from another one.
+--
+-- Like 'link', this works bidirectionally.
+--
+-- See 'link'.
+unlink :: (MonadProcess r m, MonadIO m) => ProcessId -> m ()
+unlink = liftMonadProcess id . unlinkSTM
+{-# SPECIALIZE unlink :: ProcessId -> Process r () #-}
+
+monitorSTM :: ProcessId -> ReaderT (ProcessEnv r) STM MonitorRef
+monitorSTM !pid = do
+  thisProcess <- reader processEnvProcessContext
+  mid <- newMonitorRefId
+  let ref = MonitorRef mid pid (processContextId thisProcess)
+  withReaderT processEnvNodeContext (lookupProcess pid) >>= \case
+    Nothing -> lift $ do
+      let down = Down ref pid (Just $ toException $ NoProc pid)
+      sendLazySTM thisProcess down
+    Just pc -> lift $ do
+      Set.insert ref (processContextMonitors pc)
+      Set.insert ref (processContextMonitorees thisProcess)
+  pure ref
+  where
+    newMonitorRefId = withReaderT processEnvNodeContext $ do
+      c <- readTVarR nodeContextNextMonitorRefId
+      writeTVarR nodeContextNextMonitorRefId $!! succMonitorRefId c
+      pure c
+
+-- | Monitor another process.
+--
+-- When the monitored process stops (or doesn't exist in the first place), a
+-- 'Down' message is sent to this process' mailbox.
+monitor :: (MonadProcess r m, MonadIO m) => ProcessId -> m MonitorRef
+monitor = liftMonadProcess id . monitorSTM
+{-# SPECIALIZE monitor :: ProcessId -> Process r MonitorRef #-}
+
+-- | Options for the 'demonitor' action.
+data DemonitorOption
+  = -- | Remove any 'Down' messages for the given 'MonitorRef' from the
+    -- process mailbox before returning.
+    DemonitorFlush
+  deriving (Show, Eq)
+
+newtype InvariantViolation = InvariantViolation String
+  deriving (Show)
+
+instance Exception InvariantViolation where
+  displayException (InvariantViolation s) = "Invariant violation: " <> s
+
+demonitorSTM :: MonitorRef -> ReaderT (ProcessEnv r) STM ()
+demonitorSTM !ref = do
+  thisProcess <- reader processEnvProcessContext
+  if monitorRefMonitor ref /= processContextId thisProcess
+    then lift $ throwSTM (InvalidMonitorRef ref)
+    else
+      withReaderT processEnvNodeContext (lookupProcess $ monitorRefMonitoree ref) >>= \case
+        Nothing -> lift $ do
+          -- Process no longer exists, hence, the ref should no longer
+          -- be in the tracking sets, otherwise, there's a bug.
+          Set.lookup ref (processContextMonitorees thisProcess) >>= \case
+            True -> throwSTM $ InvariantViolation "demonitorSTM: ref in monitorees, but monitor gone"
+            False -> pure ()
+        Just pc -> lift $ do
+          Set.delete ref (processContextMonitors pc)
+          Set.delete ref (processContextMonitorees thisProcess)
+
+-- | Cancel a 'MonitorRef'.
+--
+-- Keep in mind a 'Down' message could have been delivered before (or while)
+-- 'demonitor' is called, hence such message could be found in the mailbox
+-- after calling 'demonitor', unless the 'DemonitorFlush' option is used.
+--
+-- Note: this throws an 'InvalidMonitorRef' exception when called with a
+-- 'MonitorRef' created from a call to 'monitor' from another process.
+--
+-- See 'monitor'.
+demonitor :: (MonadProcess r m, MonadIO m) => [DemonitorOption] -> MonitorRef -> m ()
+demonitor !options !ref = do
+  liftMonadProcess id $ demonitorSTM ref
+  when (DemonitorFlush `elem` options) $ do
+    void $
+      receiveTimeout
+        0
+        [ matchIf (\d -> downMonitorRef d == ref) (\_ -> pure ())
+        ]
+{-# SPECIALIZE demonitor :: [DemonitorOption] -> MonitorRef -> Process r () #-}
+
+exitSTM :: (Exception e) => ProcessId -> Maybe e -> ReaderT (ProcessEnv r) STM ()
+exitSTM !pid !exc = do
+  thisProcess <- reader (processContextId . processEnvProcessContext)
+  withReaderT processEnvNodeContext (lookupProcess pid) >>= \case
+    Nothing -> pure () -- Process doesn't (or no longer) exists
+    Just pc -> case fmap toException exc of
+      Nothing ->
+        lift (readTVar $ processContextTrapExit pc) >>= \case
+          False -> pure ()
+          True -> lift $ do
+            let msg = Exit thisProcess pid False (fmap toException exc)
+             in sendLazySTM pc msg
+      Just exc' ->
+        if isKill exc'
+          then lift $ deliverException pc exc'
+          else
+            lift (readTVar $ processContextTrapExit pc) >>= \case
+              False -> lift $ deliverException pc exc'
+              True -> lift $ do
+                let msg = Exit thisProcess pid False (Just exc')
+                 in sendLazySTM pc msg
+
+-- | Request or force a process to exit.
+--
+-- - When the target process does not trap exits (see 'TrapExit') and no
+-- exception is provided, this is a no-op.
+-- - When the target process does not trap exits (see 'TrapExit') and an
+--  exception is provided, the exception will be raised in the target process.
+-- - When the target process traps exits (see 'TrapExit'), an 'Exit' message
+--  will be delivered to the target process with 'exitLink' set to 'False', and
+-- 'exitReason' to the given exception (or 'Nothing'), unless the exception is a
+-- 'Kill'.
+--
+-- If a 'Kill' exception is provided, it is raised in the target process, even
+-- if said process is trapping exceptions (see 'Troupe.kill').
+--
+-- Unlike the behaviour in Erlang, there's no difference between calling 'exit'
+-- with the 'ProcessId' of the calling process itself or any other process.
+exit :: (MonadProcess r m, MonadIO m, Exception e) => ProcessId -> Maybe e -> m ()
+exit !pid !exc = liftMonadProcess id $ exitSTM pid exc
+{-# SPECIALIZE exit :: (Exception e) => ProcessId -> Maybe e -> Process r () #-}
+
+-- | Check whether a process with given 'ProcessId' is alive.
+--
+-- Note this could return 'True' even though the process is no longer alive
+-- by the time this function returns. The inverse, where a process is deemed
+-- not to be alive (as returned by this function), but then is alive anyway by
+-- the time the function returns, is unlikely but should be considered possible
+-- as well.
+isProcessAlive :: (MonadProcess r m, MonadIO m) => ProcessId -> m Bool
+isProcessAlive !pid =
+  liftMonadProcess processEnvNodeContext $
+    isJust <$> lookupProcess pid
+{-# SPECIALIZE isProcessAlive :: ProcessId -> Process r Bool #-}
+
+data WithMonitor r where
+  WithMonitor :: WithMonitor (ProcessId, MonitorRef)
+  WithoutMonitor :: WithMonitor ProcessId
+
+data SpawnOptions r = SpawnOptions
+  { spawnOptionsLink :: !Bool,
+    spawnOptionsMonitor :: !(WithMonitor r)
+  }
+
+spawnWithOptions :: (MonadProcess r m, MonadIO m) => SpawnOptions t -> Process r a -> m t
+spawnWithOptions !options process = do
+  let cb pid = do
+        when (spawnOptionsLink options) $
+          linkSTM pid
+        case spawnOptionsMonitor options of
+          WithoutMonitor -> pure pid
+          WithMonitor -> do
+            ref <- monitorSTM pid
+            pure (pid, ref)
+
+  spawnImpl cb process
+{-# SPECIALIZE spawnWithOptions :: SpawnOptions t -> Process r a -> Process r t #-}
+
+-- | Spawn a new process.
+spawn :: (MonadProcess r m, MonadIO m) => Process r a -> m ProcessId
+spawn = spawnWithOptions options
+  where
+    options =
+      SpawnOptions
+        { spawnOptionsLink = False,
+          spawnOptionsMonitor = WithoutMonitor
+        }
+{-# INLINE spawn #-}
+{-# SPECIALIZE spawn :: Process r a -> Process r ProcessId #-}
+
+-- | Spawn a new process, and atomically 'link' to it.
+--
+-- See 'spawn' and 'link'.
+spawnLink :: (MonadProcess r m, MonadIO m) => Process r a -> m ProcessId
+spawnLink = spawnWithOptions options
+  where
+    options =
+      SpawnOptions
+        { spawnOptionsLink = True,
+          spawnOptionsMonitor = WithoutMonitor
+        }
+{-# INLINE spawnLink #-}
+{-# SPECIALIZE spawnLink :: Process r a -> Process r ProcessId #-}
+
+-- | Spawn a new process, and atomically 'monitor' it.
+--
+-- See 'spawn' and 'monitor'.
+spawnMonitor :: (MonadProcess r m, MonadIO m) => Process r a -> m (ProcessId, MonitorRef)
+spawnMonitor = spawnWithOptions options
+  where
+    options =
+      SpawnOptions
+        { spawnOptionsLink = False,
+          spawnOptionsMonitor = WithMonitor
+        }
+{-# INLINE spawnMonitor #-}
+{-# SPECIALIZE spawnMonitor :: Process r a -> Process r (ProcessId, MonitorRef) #-}
+
+data SendOptions = SendOptions
+
+sendWithOptions :: (MonadProcess r m, MonadIO m, Typeable a) => SendOptions -> ProcessId -> a -> m ()
+sendWithOptions SendOptions !pid a = do
+  env <- processEnvNodeContext <$> getProcessEnv
+  liftIO $
+    atomically $
+      runReaderT (lookupProcess pid) env >>= \case
+        Nothing -> pure ()
+        Just pc -> sendLazySTM pc a
+{-# SPECIALIZE sendWithOptions :: (Typeable a) => SendOptions -> ProcessId -> a -> Process r () #-}
+
+-- | Send a message to a process' mailbox.
+--
+-- The message is fully evaluated (using 'deepseq') in the current process
+-- before delivering it.
+send :: (MonadProcess r m, MonadIO m, Typeable a, NFData a) => ProcessId -> a -> m ()
+send !pid !a = a `deepseq` sendWithOptions SendOptions pid a
+{-# INLINE send #-}
+{-# SPECIALIZE send :: (Typeable a, NFData a) => ProcessId -> a -> Process r () #-}
+
+-- | Send a message to a process' mailbox.
+--
+-- The message is not fully evaulated before delivering it, hence, if
+-- evaluation requires large computations, or fails, this will be observed
+-- in the receiving process.
+--
+-- In general, prefer using 'send' and provide an 'NFData' instance of
+-- message types.
+sendLazy :: (MonadProcess r m, MonadIO m, Typeable a) => ProcessId -> a -> m ()
+sendLazy = sendWithOptions SendOptions
+{-# INLINE sendLazy #-}
+{-# SPECIALIZE sendLazy :: (Typeable a) => ProcessId -> a -> Process r () #-}
+
+data ReceiveMethod f where
+  ReceiveBlocking :: ReceiveMethod Identity
+  ReceiveNonBlocking :: ReceiveMethod Maybe
+  ReceiveTimeout :: Int -> ReceiveMethod Maybe
+
+{- HLINT ignore ReceiveOptions "Use newtype instead of data" -}
+data ReceiveOptions f = ReceiveOptions
+  { receiveOptionsMethod :: !(ReceiveMethod f)
+  }
+
+-- | Matching clause for a value of type @a@ in monadic context @m@.
+newtype Match m a
+  = MatchMessage (Dynamic -> Maybe (m a))
+  deriving (Functor)
+
+receiveWithOptions :: (MonadProcess r m, MonadIO m) => ReceiveOptions f -> [Match m a] -> m (f a)
+receiveWithOptions !options !matches = do
+  queue <- processContextQueue . processEnvProcessContext <$> getProcessEnv
+  let bs = case receiveOptionsMethod options of
+        ReceiveBlocking -> Blocking
+        ReceiveNonBlocking -> NonBlocking
+        ReceiveTimeout t -> Timeout t
+      matches' = map (\(MatchMessage fn) -> MatchMsg fn) matches
+  p <- liftIO $ dequeue queue bs matches'
+  case p of
+    Nothing -> case receiveOptionsMethod options of
+      ReceiveBlocking -> error "receiveWithOptions: dequeue returned Nothing in Blocking call"
+      ReceiveNonBlocking -> pure Nothing
+      ReceiveTimeout _ -> pure Nothing
+    Just a -> case receiveOptionsMethod options of
+      ReceiveBlocking -> Identity <$> a
+      ReceiveNonBlocking -> Just <$> a
+      ReceiveTimeout _ -> Just <$> a
+{-# SPECIALIZE receiveWithOptions :: ReceiveOptions f -> [Match (Process r) a] -> Process r (f a) #-}
+
+-- | Receive some message from the process mailbox, blocking.
+receive :: (MonadProcess r m, MonadIO m) => [Match m a] -> m a
+receive !matches = runIdentity <$> receiveWithOptions options matches
+  where
+    options =
+      ReceiveOptions
+        { receiveOptionsMethod = ReceiveBlocking
+        }
+{-# INLINE receive #-}
+{-# SPECIALIZE receive :: [Match (Process r) a] -> Process r a #-}
+
+-- | Receive some message from the process mailbox.
+--
+-- If the given timeout is @0@, this works in a non-blocking way. Otherwise,
+-- the call will time out after the given number of microseconds.
+--
+-- If no message is matched within the timeout period, 'Nothing' is returned,
+-- otherwise @'Just' a@.
+receiveTimeout :: (MonadProcess r m, MonadIO m) => Int -> [Match m a] -> m (Maybe a)
+receiveTimeout !t = receiveWithOptions options
+  where
+    options =
+      ReceiveOptions
+        { receiveOptionsMethod = if t == 0 then ReceiveNonBlocking else ReceiveTimeout t
+        }
+{-# INLINE receiveTimeout #-}
+{-# SPECIALIZE receiveTimeout :: Int -> [Match (Process r) a] -> Process r (Maybe a) #-}
+
+-- | Utility to 'receive' a value of a specific type.
+expect :: (MonadProcess r m, MonadIO m, Typeable a) => m a
+expect = receive [match pure]
+{-# INLINE expect #-}
+{-# SPECIALIZE expect :: (Typeable a) => Process r a #-}
+
+-- | Match any message of a specific type.
+match :: (Typeable a) => (a -> m b) -> Match m b
+match = matchIf (const True)
+{-# INLINE match #-}
+
+-- | Match any message meeting some predicate of a specific type.
+matchIf :: (Typeable a) => (a -> Bool) -> (a -> m b) -> Match m b
+matchIf check handle = MatchMessage $ \dyn -> case fromDynamic dyn of
+  Nothing -> Nothing
+  Just a -> if check a then Just (handle a) else Nothing
+{-# INLINE matchIf #-}
+
+spawnImpl :: (MonadProcess r m, MonadIO m) => (ProcessId -> ReaderT (ProcessEnv r) STM t) -> Process r a -> m t
+spawnImpl cb process = do
+  currentEnv <- getProcessEnv
+
+  liftIO $ do
+    processContext <- newProcessContext (processEnvNodeContext currentEnv)
+    let processEnv = currentEnv {processEnvProcessContext = processContext}
+
+    m <- newEmptyTMVarIO
+
+    bracketOnError
+      (run currentEnv processEnv m)
+      uninterruptibleCancel
+      (wrapup m)
+  where
+    run currentEnv processEnv m = mask_ $ async $ do
+      c <- newEmptyTMVarIO
+      let act restore = atomically (readTMVar c) >>= \() -> restore (runProcess process processEnv)
+
+      withAsyncWithUnmask act $ \a -> do
+        let pid = processContextId (processEnvProcessContext processEnv)
+
+        -- 1. Register the process on the node, calculate the result value of `spawnImpl`, and
+        -- let the process actually run
+        let register = atomically $ do
+              registerProcess (processEnvNodeContext processEnv) (processEnvProcessContext processEnv)
+              r <- runReaderT (cb pid) currentEnv
+              writeTMVar c ()
+              writeTMVar m r
+
+        -- 2. Wait for either the process thread to return (successfully or with an exception,
+        -- don't really care at this point), or an exception to be delivered to the process
+        -- to be set.
+        -- In the second case, cancel the `Async` with said exception.
+        let wait = atomically $ do
+              Left <$> waitCatchSTM a
+                <|> Right <$> readTQueue (processContextExceptions $ processEnvProcessContext processEnv)
+
+            loop =
+              wait >>= \case
+                Left _ -> pure ()
+                Right exc -> do
+                  uninterruptibleCancelWith a exc
+                  loop
+
+        -- 3. At this point, either the `Async` already returned, or we canceled it.
+        -- Wait for it again (this should not actually block, since we know it has exited
+        -- already at this point), and perform whichever effects are supposed to happen,
+        -- including unregistering the process, removing the process as a monitor from its
+        -- monitorees, notify all its monitors, and deliver signals or messages to linked
+        -- processes (also, removing the link).
+        let cleanup = atomically $ flip runReaderT processEnv $ do
+              res <-
+                lift (waitCatchSTM a) >>= \case
+                  Left exn -> pure (Just exn)
+                  Right _ -> pure Nothing
+
+              unregisterProcess pid
+              handleMonitorees
+              handleMonitors pid res
+              handleLinks pid res
+
+        ( (register >>= \() -> loop)
+            `withException` \e ->
+              uninterruptibleCancelWith a (e :: SomeException)
+          )
+          `finally` cleanup
+
+    -- Like uninterruptibleCancel, but with a custom exception
+    uninterruptibleCancelWith a e =
+      uninterruptibleMask_ (cancelWith a e)
+
+    registerProcess nodeContext processContext =
+      Map.insert processContext (processContextId processContext) (nodeContextProcesses nodeContext)
+
+    unregisterProcess pid =
+      reader (nodeContextProcesses . processEnvNodeContext) >>= lift . Map.delete pid
+
+    handleMonitorees = do
+      monitorees <- reader (processContextMonitorees . processEnvProcessContext)
+      nodeContext <- reader processEnvNodeContext
+      lift $ forM_ (Set.unfoldlM monitorees) $ \ref -> do
+        runReaderT (lookupProcess (monitorRefMonitoree ref)) nodeContext >>= \case
+          Nothing -> throwSTM $ InvariantViolation "spawnImpl: monitoree doesn't exist"
+          Just pc -> do
+            Set.delete ref (processContextMonitors pc)
+
+    handleMonitors pid res = do
+      monitors <- reader (processContextMonitors . processEnvProcessContext)
+      nodeContext <- reader processEnvNodeContext
+      lift $ forM_ (Set.unfoldlM monitors) $ \ref -> do
+        runReaderT (lookupProcess (monitorRefMonitor ref)) nodeContext >>= \case
+          Nothing -> throwSTM $ InvariantViolation "spawnImpl: monitor doesn't exist"
+          Just pc -> do
+            Set.delete ref (processContextMonitorees pc)
+            let down = Down ref pid (fmap convertKillToKilled res)
+            sendLazySTM pc down
+
+    handleLinks linkee res = do
+      links <- reader (processContextLinks . processEnvProcessContext)
+      nodeContext <- reader processEnvNodeContext
+      lift $ forM_ (Set.unfoldlM links) $ \pid2 -> do
+        runReaderT (lookupProcess pid2) nodeContext >>= \case
+          Nothing -> throwSTM $ InvariantViolation "spawnImpl: linkee doesn't exist"
+          Just pc -> do
+            let exc = Exit linkee pid2 True res
+            Set.delete linkee (processContextLinks pc)
+            deliverExit pc exc
+
+    wrapup m a = do
+      res <- atomically $ (Left <$> waitCatchSTM a) <|> (Right <$> readTMVar m)
+      case res of
+        Left l -> case l of
+          Left exc -> throwM exc
+          Right () -> do
+            -- A case where `a` returned successfully (i.e., process exited), and
+            -- this was noticed before we could read out `m` (ordering of the `<|>`
+            -- clause above). However, we know from the implementation above, that
+            -- if `a` returned successfully, `m` must be filled.
+            atomically (tryReadTMVar m) >>= \case
+              Nothing -> throwM $ InvariantViolation "spawnImpl: impossible case, Async returned but TMVar empty"
+              Just t -> pure t
+        Right t -> pure t
+{-# SPECIALIZE spawnImpl :: (ProcessId -> ReaderT (ProcessEnv r) STM t) -> Process r a -> Process r t #-}

--- a/troupe/src/Troupe/Types.hs
+++ b/troupe/src/Troupe/Types.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE Strict #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+
+module Troupe.Types
+  ( ProcessId,
+    processId0,
+    succProcessId,
+    MonitorRefId,
+    monitorRefId0,
+    succMonitorRefId,
+    MonitorRef (..),
+    Down (..),
+  )
+where
+
+import Control.DeepSeq (NFData (..), deepseq, ($!!))
+import Control.Exception.Base (SomeException)
+import Data.Hashable (Hashable (..))
+import Data.Word (Word64)
+
+-- | Identifier of some process.
+newtype ProcessId = ProcessId Word64
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Hashable, NFData)
+
+processId0 :: ProcessId
+processId0 = ProcessId 0
+
+succProcessId :: ProcessId -> ProcessId
+succProcessId (ProcessId p) = ProcessId $!! succ p
+{-# INLINE succProcessId #-}
+
+-- | Identifier of a 'MonitorRef'.
+newtype MonitorRefId = MonitorRefId Word64
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (Hashable, NFData)
+
+monitorRefId0 :: MonitorRefId
+monitorRefId0 = MonitorRefId 0
+
+succMonitorRefId :: MonitorRefId -> MonitorRefId
+succMonitorRefId (MonitorRefId r) = MonitorRefId $!! succ r
+{-# INLINE succMonitorRefId #-}
+
+-- | Reference to a monitor on a process.
+--
+-- See 'Troupe.monitor' and 'Troupe.demonitor'.
+data MonitorRef = MonitorRef
+  { monitorRefId :: {-# UNPACK #-} !MonitorRefId,
+    monitorRefMonitoree :: {-# UNPACK #-} !ProcessId,
+    monitorRefMonitor :: {-# UNPACK #-} !ProcessId
+  }
+  deriving (Show, Eq, Ord)
+
+instance NFData MonitorRef where
+  rnf (MonitorRef i e m) = i `deepseq` e `deepseq` m `deepseq` ()
+
+instance Hashable MonitorRef where
+  hashWithSalt s (MonitorRef i e m) =
+    s
+      `hashWithSalt` i
+      `hashWithSalt` e
+      `hashWithSalt` m
+
+-- | Message delivered when a monitored process stops (either by returning
+-- successfully, or because of some exception).
+--
+-- See 'Troupe.monitor'.
+data Down = Down
+  { -- | 'MonitorRef' causing this 'Down' message to be delivered.
+    downMonitorRef :: {-# UNPACK #-} !MonitorRef,
+    -- | 'ProcessId' of the monitored process that stopped.
+    downProcessId :: {-# UNPACK #-} !ProcessId,
+    -- | Reason for the process to stop. 'Nothing' if successful, @'Just' e@
+    -- when stopped with some exception.
+    downReason :: !(Maybe SomeException)
+  }
+  deriving (Show)

--- a/troupe/test/Main.hs
+++ b/troupe/test/Main.hs
@@ -1,4 +1,0 @@
-module Main (main) where
-
-main :: IO ()
-main = putStrLn "Test suite not yet implemented."

--- a/troupe/test/Troupe/Test.hs
+++ b/troupe/test/Troupe/Test.hs
@@ -1,0 +1,407 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Troupe.Test (tests) where
+
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
+import Control.DeepSeq (NFData (..))
+import Control.Exception.Safe (Exception, Handler (..), bracket, catch, catchesAsync, fromException, mask, throwM)
+import Control.Monad (forever)
+import Control.Monad.IO.Class (liftIO)
+import GHC.Generics (Generic)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase, (@?=))
+import Troupe
+  ( DemonitorOption (..),
+    Down (..),
+    Exit (..),
+    Killed (..),
+    NoProc (..),
+    Process,
+    ProcessId,
+    ProcessOption (..),
+    demonitor,
+    exit,
+    expect,
+    isProcessAlive,
+    kill,
+    link,
+    match,
+    matchIf,
+    monitor,
+    receive,
+    receiveTimeout,
+    runNode,
+    self,
+    send,
+    setProcessOption,
+    spawn,
+    spawnLink,
+    spawnMonitor,
+  )
+
+troupeTest :: r -> Process r a -> Assertion
+troupeTest r root = do
+  m <- newEmptyMVar
+
+  runNode r $ do
+    (_, ref) <- spawnMonitor root
+    receive
+      [ matchIf
+          (\d -> downMonitorRef d == ref)
+          ( \d -> liftIO $ case downReason d of
+              Nothing -> putMVar m (Right ())
+              Just exc -> putMVar m (Left exc)
+          )
+      ]
+
+  takeMVar m >>= \case
+    Left exc -> throwM exc
+    Right () -> pure ()
+
+newtype Ping = Ping ProcessId
+  deriving newtype (NFData)
+
+data Pong = Pong
+  deriving (Generic)
+  deriving anyclass (NFData)
+
+data TestException = TestException
+  deriving (Show, Eq)
+
+instance Exception TestException
+
+instance NFData TestException where
+  rnf t = t `seq` ()
+
+tests :: TestTree
+tests =
+  testGroup
+    "Troupe"
+    [ testCase "Ping-pong" $ troupeTest () $ do
+        let ponger = forever $ do
+              Ping p <- expect
+              send p Pong
+
+        withProcess ponger $ \pid -> do
+          send pid . Ping =<< self
+          Pong <- expect
+          pure (),
+      testGroup
+        "link"
+        [ testCase "Simple scenario" $ troupeTest () $ do
+            (pid1, ref1) <- spawnMonitor $ do
+              -- Block
+              () <- expect
+              pure ()
+
+            (pid2, ref2) <- spawnMonitor $ do
+              link pid1
+              throwM TestException
+
+            down1 <-
+              receive
+                [ matchIf (\d -> downMonitorRef d == ref1) pure
+                ]
+            down2 <-
+              receive
+                [ matchIf (\d -> downMonitorRef d == ref2) pure
+                ]
+
+            liftIO $ do
+              downMonitorRef down1 @?= ref1
+              downProcessId down1 @?= pid1
+              case downReason down1 of
+                Nothing -> assertFailure "Expected downReason to be some exception"
+                Just dr -> case fromException dr of
+                  Nothing -> assertFailure $ "Expected downReason to be an Exit exception: " <> show dr
+                  Just e -> case exitReason e of
+                    Nothing -> assertFailure "Expected exitReason to be some exception"
+                    Just er -> case fromException er of
+                      Nothing -> assertFailure $ "Expected exitReason to be a TestException: " <> show er
+                      Just TestException -> pure ()
+
+              downMonitorRef down2 @?= ref2
+              downProcessId down2 @?= pid2
+              case downReason down2 of
+                Nothing -> assertFailure "Expected downReason to be some exception"
+                Just dr -> case fromException dr of
+                  Nothing -> assertFailure $ "Expected downReason to be a TestException: " <> show dr
+                  Just TestException -> pure ()
+
+            receiveTimeout 0 [match pure] >>= \case
+              Nothing -> pure ()
+              Just Down {} -> liftIO $ assertFailure "unexpected Down message",
+          testGroup
+            "link is bidirectional"
+            [ testCase "linker throws" $ troupeTest () $ do
+                (pid1, ref1) <- spawnMonitor $ do
+                  () <- expect
+                  pure ()
+                (_, ref2) <- spawnMonitor $ do
+                  link pid1
+                  throwM TestException
+                awaitProcessExit ref1
+                awaitProcessExit ref2,
+              testCase "linkee throws" $ troupeTest () $ do
+                m <- liftIO newEmptyMVar
+
+                (pid1, ref1) <- spawnMonitor $ do
+                  liftIO $ takeMVar m
+                  throwM TestException
+
+                (_, ref2) <- spawnMonitor $ do
+                  link pid1
+                  mask $ \restore -> do
+                    liftIO $ putMVar m ()
+                    restore $ do
+                      () <- expect
+                      pure ()
+
+                awaitProcessExit ref1
+                awaitProcessExit ref2
+            ]
+        ],
+      testGroup
+        "monitor"
+        [ testCase "Unexceptional" $ troupeTest () $ do
+            m <- liftIO newEmptyMVar
+            pid <- spawn $ liftIO $ takeMVar m
+            ref <- monitor pid
+            liftIO $ putMVar m ()
+
+            Down ref' pid' Nothing <- expect
+            liftIO $ do
+              ref' @?= ref
+              pid' @?= pid,
+          testCase "Exceptional" $ troupeTest () $ do
+            m <- liftIO newEmptyMVar
+            pid <- spawn $ do
+              liftIO $ takeMVar m
+              throwM TestException
+            ref <- monitor pid
+            liftIO $ putMVar m ()
+
+            Down ref' pid' (Just exc) <- expect
+            liftIO $ do
+              ref' @?= ref
+              pid' @?= pid
+              fromException exc @?= Just TestException,
+          testCase "NoProc" $ troupeTest () $ do
+            (pid, ref) <- spawnMonitor (pure ())
+            awaitProcessExit ref
+
+            -- Here, we know `pid` already exited
+            ref2 <- monitor pid
+            Down ref2' pid' (Just exc) <- expect
+            liftIO $ do
+              ref2' @?= ref2
+              pid' @?= pid
+              fromException exc @?= Just (NoProc pid)
+        ],
+      testGroup
+        "demonitor"
+        [ testCase "Default" $ troupeTest () $ do
+            _ <- setProcessOption TrapExit True
+            m <- liftIO newEmptyMVar
+            (pid, ref) <- spawnMonitor (liftIO $ takeMVar m)
+            link pid
+            demonitor [] ref
+            liftIO $ putMVar m ()
+            Exit _ _ _ Nothing <- expect
+            receiveTimeout 0 [matchMonitor ref] >>= \res -> liftIO $ do
+              res @?= Nothing,
+          testCase "DemonitorFlush" $ troupeTest () $ do
+            m <- liftIO newEmptyMVar
+            (pid, ref) <- spawnMonitor $ do
+              liftIO $ takeMVar m
+              throwM TestException
+            (_, ref2) <- spawnMonitor $ do
+              link pid
+              liftIO $ putMVar m ()
+              () <- expect
+              pure ()
+
+            receive [matchMonitor ref]
+            demonitor [DemonitorFlush] ref2
+            receiveTimeout 0 [matchMonitor ref2] >>= \res -> liftIO $ do
+              res @?= Nothing
+        ],
+      testGroup
+        "ProcessOption"
+        [ testGroup
+            "TrapExit"
+            [ testCase "Unexceptional" $ troupeTest () $ do
+                _ <- setProcessOption TrapExit True
+                pid <- spawnLink (pure ())
+                Exit pid' _ True Nothing <- expect
+                liftIO $ pid' @?= pid,
+              testCase "Exceptional" $ troupeTest () $ do
+                _ <- setProcessOption TrapExit True
+                pid <- spawnLink (throwM TestException)
+                Exit pid' _ True (Just exc) <- expect
+                liftIO $ do
+                  pid' @?= pid
+                  fromException exc @?= Just TestException
+            ]
+        ],
+      testGroup
+        "exit"
+        [ testGroup
+            "No TrapExit"
+            [ testCase "No exception" $ troupeTest () $ do
+                m <- liftIO newEmptyMVar
+                s <- self
+
+                (pid, ref) <- spawnMonitor $ do
+                  liftIO $ takeMVar m
+                  send s ()
+
+                exit pid (Nothing :: Maybe TestException)
+
+                liftIO $ putMVar m ()
+                () <- expect
+                awaitProcessExit ref,
+              testCase "Regular exception" $ troupeTest () $ do
+                (pid, _) <- spawnMonitor $ do
+                  () <- expect
+                  pure ()
+
+                exit pid (Just TestException)
+
+                Down _ pid' exc <- expect
+                liftIO $ do
+                  pid' @?= pid
+                  fmap fromException exc @?= Just (Just TestException),
+              testCase "Regular exception, catching" $ troupeTest () $ do
+                s <- self
+                (pid, _) <- spawnMonitor $ do
+                  (do () <- expect; pure ()) `catch` \TestException -> send s ()
+
+                exit pid (Just TestException)
+                () <- expect
+
+                Down _ _ Nothing <- expect
+                pure (),
+              testCase "Kill" $ troupeTest () $ do
+                (pid, _) <- spawnMonitor $ do
+                  () <- expect
+                  pure ()
+
+                exit pid (Just $ kill "Die")
+
+                Down _ pid' exc <- expect
+                liftIO $ do
+                  pid' @?= pid
+                  fmap fromException exc @?= Just (Just $ Killed "Die"),
+              testCase "Kill accross a link" $ troupeTest () $ do
+                s <- self
+
+                (pid1, ref1) <- spawnMonitor $ do
+                  s' <- self
+                  link s
+                  pid2 <- expect
+                  send pid2 ()
+                  (do () <- expect; pure ())
+                    `catchesAsync` [ Handler
+                                       ( \e@Exit {} -> do
+                                           liftIO $ do
+                                             exitSender e @?= pid2
+                                             exitReceiver e @?= s'
+                                             exitLink e @?= True
+                                             fmap fromException (exitReason e) @?= Just (Just (Killed "Die"))
+                                           send s ()
+                                       )
+                                   ]
+
+                (pid2, ref2) <- spawnMonitor $ do
+                  link pid1
+                  s' <- self
+                  send pid1 s'
+                  () <- expect
+                  send s ()
+                  (do () <- expect; pure ())
+
+                () <- expect
+                exit pid2 (Just $ kill "Die")
+
+                () <- expect
+
+                awaitProcessExit ref2
+                awaitProcessExit ref1
+            ],
+          testGroup
+            "TrapExit"
+            [ testCase "No exception" $ troupeTest () $ do
+                s <- self
+
+                (pid, ref) <- spawnMonitor $ do
+                  _ <- setProcessOption TrapExit True
+                  send s ()
+                  pid <- self
+                  Exit s' pid' False Nothing <- expect
+                  liftIO $ do
+                    s' @?= s
+                    pid' @?= pid
+
+                link pid
+                () <- expect
+                exit pid (Nothing :: Maybe TestException)
+                awaitProcessExit ref,
+              testCase "Regular exception" $ troupeTest () $ do
+                s <- self
+
+                (pid, ref) <- spawnMonitor $ do
+                  _ <- setProcessOption TrapExit True
+                  send s ()
+                  pid <- self
+                  Exit s' pid' False (Just exc) <- expect
+                  liftIO $ do
+                    s' @?= s
+                    pid' @?= pid
+                    fromException exc @?= Just TestException
+
+                link pid
+                () <- expect
+                exit pid (Just TestException)
+                awaitProcessExit ref,
+              testCase "Kill" $ troupeTest () $ do
+                s <- self
+
+                (pid, _) <- spawnMonitor $ do
+                  _ <- setProcessOption TrapExit True
+                  send s ()
+                  () <- expect
+                  pure ()
+
+                () <- expect
+                exit pid (Just $ kill "Die")
+                Down _ _ (Just exc) <- expect
+                liftIO $ fromException exc @?= Just (Killed "Die")
+            ]
+        ],
+      testCase "isProcessAlive" $ troupeTest () $ do
+        (pid, ref) <- spawnMonitor $ do
+          () <- expect
+          pure ()
+
+        a <- isProcessAlive pid
+        liftIO $ a @?= True
+
+        exit pid (Just $ kill "Die")
+        awaitProcessExit ref
+
+        a' <- isProcessAlive pid
+        liftIO $ a' @?= False
+    ]
+  where
+    matchMonitor ref = matchIf (\d -> downMonitorRef d == ref) (\_ -> pure ())
+    awaitProcessExit ref = receive [matchMonitor ref]
+    withProcess p act = bracket (spawnMonitor p) cleanup (\(pid, _) -> act pid)
+      where
+        cleanup (pid, ref) = do
+          exit pid (Just $ kill "End of withProcess scope")
+          awaitProcessExit ref

--- a/troupe/test/Troupe/Test.hs
+++ b/troupe/test/Troupe/Test.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Troupe.Test (tests) where
 
@@ -41,6 +42,7 @@ import Troupe
     spawn,
     spawnLink,
     spawnMonitor,
+    pattern IsExit,
   )
 
 troupeTest :: r -> Process r a -> Assertion
@@ -414,7 +416,44 @@ tests =
         awaitProcessExit ref
 
         a' <- isProcessAlive pid
-        liftIO $ a' @?= False
+        liftIO $ a' @?= False,
+      testGroup
+        "Non-regression"
+        [ testCase "Deliver signals before/when receiving messages (#25)" $ troupeTest () $ do
+            -- The "main" test thread
+            (_, _) <- spawnMonitor $ do
+              mv <- liftIO newEmptyMVar
+              -- The child thread
+              pid <- spawnLink $ do
+                liftIO $ takeMVar mv
+                -- Unconditional failure
+                throwM TestException
+              -- When this returns, the main thread is linked to the thread,
+              -- and monitoring it.
+              _ref <- monitor pid
+              liftIO $ putMVar mv ()
+
+              -- Wait for the monitor. However, if `Down` is delivered, this
+              -- is because the child exited, with an exception (there's no
+              -- other way for it to exit), in which case, through the link,
+              -- this thread should be killed as well. Hence, `expect` should
+              -- not return and this process should exit with an exception,
+              -- as observed by the test process through a monitor.
+              --
+              -- Before the fix, putting a
+              -- () <- expect
+              -- here, which will never be fulfilled, makes the test succeed:
+              -- this thread blocks, the Exit exception from the link can be
+              -- injected, and we're good.
+              Down {} <- expect
+              pure ()
+
+            Down _ _ exc <- expect
+
+            liftIO $ case exc of
+              Just (IsExit _ _ True (Just exc')) -> fromException exc' @?= Just TestException
+              _ -> assertFailure "Expected an Exit exception"
+        ]
     ]
   where
     matchMonitor ref = matchIf (\d -> downMonitorRef d == ref) (\_ -> pure ())

--- a/troupe/test/troupe-test.hs
+++ b/troupe/test/troupe-test.hs
@@ -1,0 +1,12 @@
+module Main (main) where
+
+import Test.Tasty (defaultMain, testGroup)
+import qualified Troupe.Test as T
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "troupe-test"
+      [ T.tests
+      ]

--- a/troupe/troupe-distributed-process/Control/Distributed/Process/Internal/CQueue.hs
+++ b/troupe/troupe-distributed-process/Control/Distributed/Process/Internal/CQueue.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards, ScopedTypeVariables, RankNTypes #-}
+-- | Concurrent queue for single reader, single writer
+module Control.Distributed.Process.Internal.CQueue
+  ( CQueue
+  , BlockSpec(..)
+  , MatchOn(..)
+  , newCQueue
+  , enqueue
+  , enqueueSTM
+  , dequeue
+  , mkWeakCQueue
+  , queueSize
+  ) where
+
+import Prelude hiding (length, reverse)
+import Control.Concurrent.STM
+  ( atomically
+  , STM
+  , TChan
+  , TVar
+  , modifyTVar'
+  , tryReadTChan
+  , newTChan
+  , newTVarIO
+  , writeTChan
+  , readTChan
+  , readTVarIO
+  , orElse
+  , retry
+  )
+import Control.Applicative ((<$>), (<*>))
+import Control.Exception (mask_, onException)
+import System.Timeout (timeout)
+import Control.Distributed.Process.Internal.StrictMVar
+  ( StrictMVar(StrictMVar)
+  , newMVar
+  , takeMVar
+  , putMVar
+  )
+import Control.Distributed.Process.Internal.StrictList
+  ( StrictList(..)
+  , append
+  )
+import Data.Maybe (fromJust)
+import Data.Traversable (traverse)
+import GHC.MVar (MVar(MVar))
+import GHC.IO (IO(IO), unIO)
+import GHC.Exts (mkWeak#)
+import GHC.Weak (Weak(Weak))
+
+-- We use a TCHan rather than a Chan so that we have a non-blocking read
+data CQueue a = CQueue (StrictMVar (StrictList a)) -- Arrived
+                       (TChan a)                   -- Incoming
+                       (TVar Int)                 -- Queue size
+
+newCQueue :: IO (CQueue a)
+newCQueue = CQueue <$> newMVar Nil <*> atomically newTChan <*> newTVarIO 0
+
+-- | Enqueue an element
+--
+-- Enqueue is strict.
+enqueue :: CQueue a -> a -> IO ()
+enqueue c !a = atomically (enqueueSTM c a)
+
+-- | Variant of enqueue for use in the STM monad.
+enqueueSTM :: CQueue a -> a -> STM ()
+enqueueSTM (CQueue _arrived incoming size) !a = do
+   writeTChan incoming a
+   modifyTVar' size succ
+
+data BlockSpec =
+    NonBlocking
+  | Blocking
+  | Timeout Int
+
+-- Match operations
+--
+-- They can be either a message match or a channel match.
+data MatchOn m a
+ = MatchMsg  (m -> Maybe a)
+ | MatchChan (STM a)
+ deriving (Functor)
+
+-- Lists of chunks of matches
+--
+-- Two consecutive chunks never have the same kind of matches. i.e. if one chunk
+-- contains message matches then the next one must contain channel matches and
+-- viceversa.
+type MatchChunks m a = [Either [m -> Maybe a] [STM a]]
+
+-- Splits a list of matches into chunks.
+--
+-- > concatMap (either (map MatchMsg) (map MatchChan)) . chunkMatches == id
+--
+chunkMatches :: [MatchOn m a] -> MatchChunks m a
+chunkMatches [] = []
+chunkMatches (MatchMsg m : ms) = Left (m : chk) : chunkMatches rest
+   where (chk, rest) = spanMatchMsg ms
+chunkMatches (MatchChan r : ms) = Right (r : chk) : chunkMatches rest
+   where (chk, rest) = spanMatchChan ms
+
+-- | @spanMatchMsg = first (map (\(MatchMsg x) -> x)) . span isMatchMsg@
+spanMatchMsg :: [MatchOn m a] -> ([m -> Maybe a], [MatchOn m a])
+spanMatchMsg [] = ([],[])
+spanMatchMsg (m : ms)
+    | MatchMsg msg <- m = (msg:msgs, rest)
+    | otherwise         = ([], m:ms)
+    where !(msgs,rest) = spanMatchMsg ms
+
+-- | @spanMatchMsg = first (map (\(MatchChan x) -> x)) . span isMatchChan@
+spanMatchChan :: [MatchOn m a] -> ([STM a], [MatchOn m a])
+spanMatchChan [] = ([],[])
+spanMatchChan (m : ms)
+    | MatchChan stm <- m = (stm:stms, rest)
+    | otherwise          = ([], m:ms)
+    where !(stms,rest)  = spanMatchChan ms
+
+-- | Dequeue an element
+--
+-- The timeout (if any) is applied only to waiting for incoming messages, not
+-- to checking messages that have already arrived
+dequeue :: forall m a.
+           CQueue m          -- ^ Queue
+        -> BlockSpec         -- ^ Blocking behaviour
+        -> [MatchOn m a]     -- ^ List of matches
+        -> IO (Maybe a)      -- ^ 'Nothing' only on timeout
+dequeue (CQueue arrived incoming size) blockSpec matchons = mask_ $ decrementJust $
+  case blockSpec of
+    Timeout n -> timeout n $ fmap fromJust run
+    _other    ->
+       case chunks of
+         [Right ports] -> -- channels only, this is easy:
+           case blockSpec of
+             NonBlocking -> atomically $ waitChans ports (return Nothing)
+             _           -> atomically $ waitChans ports retry
+                              -- no onException needed
+         _other -> run
+  where
+    -- Decrement counter is smth is returned from the queue,
+    -- this is safe to use as method is called under a mask
+    -- and there is no 'unmasked' operation inside
+    decrementJust :: IO (Maybe (Either a a)) -> IO (Maybe a)
+    decrementJust f =
+       traverse (either return (\x -> decrement >> return x)) =<< f
+    decrement = atomically $ modifyTVar' size pred
+
+    chunks = chunkMatches matchons
+
+    run = do
+           arr <- takeMVar arrived
+           let grabNew xs = do
+                 r <- atomically $ tryReadTChan incoming
+                 case r of
+                   Nothing -> return xs
+                   Just x  -> grabNew (Snoc xs x)
+           arr' <- grabNew arr
+           goCheck chunks arr'
+
+    -- Yields the value of the first succesful STM transaction as
+    -- @Just (Left v)@. If all transactions fail, yields the value of the second
+    -- argument.
+    waitChans :: [STM a] -> STM (Maybe (Either a a)) -> STM (Maybe (Either a a))
+    waitChans ports on_block =
+        foldr orElse on_block (map (fmap (Just . Left)) ports)
+
+    --
+    -- First check the MatchChunks against the messages already in the
+    -- mailbox.  For channel matches, we do a non-blocking check at
+    -- this point.
+    --
+    -- Yields @Just (Left a)@ when a channel is matched, @Just (Right a)@
+    -- when a message is matched and @Nothing@ when there are no messages and we
+    -- aren't blocking.
+    --
+    goCheck :: MatchChunks m a
+            -> StrictList m  -- messages to check, in this order
+            -> IO (Maybe (Either a a))
+
+    goCheck [] old = goWait old
+
+    goCheck (Right ports : rest) old = do
+      r <- atomically $ waitChans ports (return Nothing) -- does not block
+      case r of
+        Just _  -> returnOld old r
+        Nothing -> goCheck rest old
+
+    goCheck (Left matches : rest) old = do
+           -- checkArrived might in principle take arbitrary time, so
+           -- we ought to call restore and use an exception handler.  However,
+           -- the check is usually fast (just a comparison), and the overhead
+           -- of passing around restore and setting up exception handlers is
+           -- high.  So just don't use expensive matchIfs!
+      case checkArrived matches old of
+        (old', Just r)  -> returnOld old' (Just (Right r))
+        (old', Nothing) -> goCheck rest old'
+          -- use the result list, which is now left-biased
+
+    --
+    -- Construct an STM transaction that looks at the relevant channels
+    -- in the correct order.
+    --
+    mkSTM :: MatchChunks m a -> STM (Either m a)
+    mkSTM [] = retry
+    mkSTM (Left _ : rest)
+      = fmap Left (readTChan incoming) `orElse` mkSTM rest
+    mkSTM (Right ports : rest)
+      = foldr orElse (mkSTM rest) (map (fmap Right) ports)
+
+    waitIncoming :: IO (Maybe (Either m a))
+    waitIncoming = case blockSpec of
+      NonBlocking -> atomically $ fmap Just stm `orElse` return Nothing
+      _           -> atomically $ fmap Just stm
+     where
+      stm = mkSTM chunks
+
+    --
+    -- The initial pass didn't find a message, so now we go into blocking
+    -- mode.
+    --
+    -- Contents of 'arrived' from now on is (old ++ new), and
+    -- messages that arrive are snocced onto new.
+    --
+    goWait :: StrictList m -> IO (Maybe (Either a a))
+    goWait old = do
+      r <- waitIncoming `onException` putMVar arrived old
+      case r of
+        --  Nothing => non-blocking and no message
+        Nothing -> returnOld old Nothing
+        Just e  -> case e of
+          --
+          -- Left => message arrived in the process mailbox.  We now have to
+          -- run through the MatchChunks checking each one, because we might
+          -- have a situation where the first chunk fails to match and the
+          -- second chunk is a channel match and there *is* a message in the
+          -- channel.  In that case the channel wins.
+          --
+          Left m -> goCheck1 chunks m old
+          --
+          -- Right => message arrived on a channel first
+          --
+          Right a -> returnOld old (Just (Left a))
+
+    --
+    -- A message arrived in the process inbox; check the MatchChunks for
+    -- a valid match.
+    --
+    goCheck1 :: MatchChunks m a
+             -> m               -- single message to check
+             -> StrictList m    -- old messages we have already checked
+             -> IO (Maybe (Either a a))
+
+    goCheck1 [] m old = goWait (Snoc old m)
+
+    goCheck1 (Right ports : rest) m old = do
+      r <- atomically $ waitChans ports (return Nothing) -- does not block
+      case r of
+        Nothing -> goCheck1 rest m old
+        Just _  -> returnOld (Snoc old m) r
+
+    goCheck1 (Left matches : rest) m old = do
+      case checkMatches matches m of
+        Nothing -> goCheck1 rest m old
+        Just p  -> returnOld old (Just (Right p))
+
+    -- a common pattern for putting back the arrived queue at the end
+    returnOld :: StrictList m -> Maybe (Either a a) -> IO (Maybe (Either a a))
+    returnOld old r = do putMVar arrived old; return r
+
+    -- as a side-effect, this left-biases the list
+    checkArrived :: [m -> Maybe a] -> StrictList m -> (StrictList m, Maybe a)
+    checkArrived matches list = go list Nil
+      where
+        -- @go xs ys@ searches for a message match in @append xs ys@
+        go Nil Nil           = (Nil, Nothing)
+        go Nil r             = go r Nil
+        go (Append xs ys) tl = go xs (append ys tl)
+        go (Snoc xs x)    tl = go xs (Cons x tl)
+        go (Cons x xs)    tl
+          | Just y <- checkMatches matches x = (append xs tl, Just y)
+          | otherwise = let !(rest,r) = go xs tl in (Cons x rest, r)
+
+    checkMatches :: [m -> Maybe a] -> m -> Maybe a
+    checkMatches []     _ = Nothing
+    checkMatches (m:ms) a = case m a of Nothing -> checkMatches ms a
+                                        Just b  -> Just b
+
+-- | Weak reference to a CQueue
+mkWeakCQueue :: CQueue a -> IO () -> IO (Weak (CQueue a))
+mkWeakCQueue m@(CQueue (StrictMVar (MVar m#)) _ _) f = IO $ \s ->
+#if MIN_VERSION_base(4,9,0)
+  case mkWeak# m# m (unIO f) s of (# s1, w #) -> (# s1, Weak w #)
+#else
+  case mkWeak# m# m f s of (# s1, w #) -> (# s1, Weak w #)
+#endif
+
+queueSize :: CQueue a -> IO Int
+queueSize (CQueue _ _ size) = readTVarIO size

--- a/troupe/troupe-distributed-process/Control/Distributed/Process/Internal/StrictList.hs
+++ b/troupe/troupe-distributed-process/Control/Distributed/Process/Internal/StrictList.hs
@@ -1,0 +1,27 @@
+-- | Spine and element strict list
+module Control.Distributed.Process.Internal.StrictList
+  ( StrictList(..)
+  , append
+  , foldr
+  ) where
+
+import Prelude hiding (length, reverse, foldr)
+
+-- | Strict list
+data StrictList a
+   = Cons !a !(StrictList a)
+   | Nil
+   | Snoc !(StrictList a) !a
+   | Append !(StrictList a) !(StrictList a)
+
+append :: StrictList a -> StrictList a -> StrictList a
+append Nil l = l
+append l Nil = l
+append l1 l2 = l1 `Append` l2
+
+foldr :: (a -> b -> b) -> b -> StrictList a -> b
+foldr f c0 xs0 = go xs0 c0
+  where go Nil            c = c
+        go (Cons x xs)    c = f x (go xs c)
+        go (Snoc xs x)    c = go xs (f x c)
+        go (Append xs ys) c = go xs (go ys c)

--- a/troupe/troupe-distributed-process/Control/Distributed/Process/Internal/StrictMVar.hs
+++ b/troupe/troupe-distributed-process/Control/Distributed/Process/Internal/StrictMVar.hs
@@ -1,0 +1,93 @@
+-- | Like Control.Concurrent.MVar.Strict but reduce to HNF, not NF
+{-# LANGUAGE CPP, MagicHash, UnboxedTuples #-}
+module Control.Distributed.Process.Internal.StrictMVar
+  ( StrictMVar(StrictMVar)
+  , newEmptyMVar
+  , newMVar
+  , takeMVar
+  , putMVar
+  , readMVar
+  , withMVar
+  , modifyMVar_
+  , modifyMVar
+  , modifyMVarMasked
+  , mkWeakMVar
+  ) where
+
+import Control.Applicative ((<$>))
+import Control.Monad ((>=>))
+#if MIN_VERSION_base(4,6,0)
+import Control.Exception (evaluate)
+#else
+import Control.Exception (evaluate, mask_, onException)
+#endif
+import qualified Control.Concurrent.MVar as MVar
+  ( MVar
+  , newEmptyMVar
+  , newMVar
+  , takeMVar
+  , putMVar
+  , readMVar
+  , withMVar
+  , modifyMVar_
+  , modifyMVar
+#if MIN_VERSION_base(4,6,0)
+  , modifyMVarMasked
+#endif
+  )
+import GHC.MVar (MVar(MVar))
+import GHC.IO (IO(IO), unIO)
+import GHC.Exts (mkWeak#)
+import GHC.Weak (Weak(Weak))
+
+newtype StrictMVar a = StrictMVar (MVar.MVar a)
+
+newEmptyMVar :: IO (StrictMVar a)
+newEmptyMVar = StrictMVar <$> MVar.newEmptyMVar
+
+newMVar :: a -> IO (StrictMVar a)
+newMVar x = evaluate x >> StrictMVar <$> MVar.newMVar x
+
+takeMVar :: StrictMVar a -> IO a
+takeMVar (StrictMVar v) = MVar.takeMVar v
+
+putMVar :: StrictMVar a -> a -> IO ()
+putMVar (StrictMVar v) x = evaluate x >> MVar.putMVar v x
+
+readMVar :: StrictMVar a -> IO a
+readMVar (StrictMVar v) = MVar.readMVar v
+
+withMVar :: StrictMVar a -> (a -> IO b) -> IO b
+withMVar (StrictMVar v) = MVar.withMVar v
+
+modifyMVar_ :: StrictMVar a -> (a -> IO a) -> IO ()
+modifyMVar_ (StrictMVar v) f = MVar.modifyMVar_ v (f >=> evaluate)
+
+modifyMVar :: StrictMVar a -> (a -> IO (a, b)) -> IO b
+modifyMVar (StrictMVar v) f = MVar.modifyMVar v (f >=> evaluateFst)
+  where
+    evaluateFst :: (a, b) -> IO (a, b)
+    evaluateFst (x, y) = evaluate x >> return (x, y)
+
+modifyMVarMasked :: StrictMVar a -> (a -> IO (a, b)) -> IO b
+modifyMVarMasked (StrictMVar v) f =
+#if MIN_VERSION_base(4,6,0)
+    MVar.modifyMVarMasked v (f >=> evaluateFst)
+#else
+  mask_ $ do
+    a      <- MVar.takeMVar v
+    (a',b) <- (f a >>= evaluate) `onException` MVar.putMVar v a
+    MVar.putMVar v a'
+    return b
+#endif
+  where
+    evaluateFst :: (a, b) -> IO (a, b)
+    evaluateFst (x, y) = evaluate x >> return (x, y)
+
+mkWeakMVar :: StrictMVar a -> IO () -> IO (Weak (StrictMVar a))
+mkWeakMVar q@(StrictMVar (MVar m#)) f = IO $ \s ->
+#if MIN_VERSION_base(4,9,0)
+  case mkWeak# m# q (unIO f) s of (# s', w #) -> (# s', Weak w #)
+#else
+  case mkWeak# m# q f s of (# s', w #) -> (# s', Weak w #)
+#endif

--- a/troupe/troupe.cabal
+++ b/troupe/troupe.cabal
@@ -41,8 +41,29 @@ common warnings
 
 library
   import:           warnings
-  exposed-modules:  MyLib
-  build-depends:    base ^>=4.17.0.0 || ^>=4.18.0.0
+  exposed-modules:  Troupe
+  other-modules:
+    Troupe.Exceptions
+    Troupe.Process
+    Troupe.Types
+
+  build-depends:
+    , async                       ^>=2.2.4
+    , base                        ^>=4.17.0.0 || ^>=4.18.0.0
+    , deepseq                     ^>=1.4.8.0
+    , deferred-folds              ^>=0.9.18.3
+    , hashable                    ^>=1.4.2.0
+    , monad-time                  ^>=0.4.0.0
+    , MonadRandom                 ^>=0.6
+    , mtl                         ^>=2.2.2    || ^>=2.3.1
+    , primitive                   ^>=0.8.0.0
+    , random                      ^>=1.2.1.1
+    , safe-exceptions             ^>=0.1.7.3
+    , stm                         ^>=2.5.1.0
+    , stm-containers              ^>=1.2.0.2
+    , transformers                ^>=0.5.6.2  || ^>=0.6.1.0
+    , troupe-distributed-process
+
   hs-source-dirs:   src
   default-language: Haskell2010
 
@@ -59,7 +80,7 @@ library troupe-distributed-process
     Control.Distributed.Process.Internal.StrictMVar
 
   build-depends:
-    , base  ^>=4.17.0.0
+    , base  ^>=4.17.0.0 || ^>=4.18.0.0
     , stm   ^>=2.5.1.0
 
   hs-source-dirs:   troupe-distributed-process
@@ -70,7 +91,13 @@ test-suite troupe-test
   default-language: Haskell2010
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
-  main-is:          Main.hs
+  main-is:          troupe-test.hs
+  other-modules:    Troupe.Test
   build-depends:
-    , base    ^>=4.17.0.0 || ^>=4.18.0.0
+    , base             ^>=4.17.0.0 || ^>=4.18.0.0
+    , deepseq          ^>=1.4.8.0
+    , safe-exceptions  ^>=0.1.7.3
+    , tasty            ^>=1.4.3
+    , tasty-hunit      ^>=0.10.0.3
+    , transformers     ^>=0.5.6.2  || ^>=0.6.1.0
     , troupe

--- a/troupe/troupe.cabal
+++ b/troupe/troupe.cabal
@@ -1,20 +1,21 @@
-cabal-version:   3.0
-build-type:      Simple
-name:            troupe
-version:         0.1.0.0
-synopsis:        Haskell Actors
-description:     A library bringing Erlang-style processes to Haskell
-homepage:        https://github.com/NicolasT/troupe
-bug-reports:     https://github.com/NicolasT/troupe/issues
-license:         BSD-3-Clause
-license-file:    LICENSE
-author:          Nicolas Trangez
-maintainer:      ikke@nicolast.be
-copyright:       (c) 2023, Nicolas Trangez
-category:        Concurrency
-stability:       alpha
-extra-doc-files: CHANGELOG.md
-tested-with:     GHC ==9.4.4 || ==9.6.1
+cabal-version:      3.0
+build-type:         Simple
+name:               troupe
+version:            0.1.0.0
+synopsis:           Haskell Actors
+description:        A library bringing Erlang-style processes to Haskell
+homepage:           https://github.com/NicolasT/troupe
+bug-reports:        https://github.com/NicolasT/troupe/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Nicolas Trangez
+maintainer:         ikke@nicolast.be
+copyright:          (c) 2023, Nicolas Trangez
+category:           Concurrency
+stability:          alpha
+extra-doc-files:    CHANGELOG.md
+extra-source-files: .hlint.yaml
+tested-with:        GHC ==9.4.4 || ==9.6.1
 
 source-repository head
   type:     git
@@ -43,6 +44,25 @@ library
   exposed-modules:  MyLib
   build-depends:    base ^>=4.17.0.0 || ^>=4.18.0.0
   hs-source-dirs:   src
+  default-language: Haskell2010
+
+-- Vendored code from the `distributed-process` library
+library troupe-distributed-process
+  import:           warnings
+
+  if flag(werror)
+    ghc-options: -Wwarn
+
+  exposed-modules:  Control.Distributed.Process.Internal.CQueue
+  other-modules:
+    Control.Distributed.Process.Internal.StrictList
+    Control.Distributed.Process.Internal.StrictMVar
+
+  build-depends:
+    , base  ^>=4.17.0.0
+    , stm   ^>=2.5.1.0
+
+  hs-source-dirs:   troupe-distributed-process
   default-language: Haskell2010
 
 test-suite troupe-test


### PR DESCRIPTION
Some code dropping. Not necessarily the way we want things to be.

- [x] Exception handling, and propagation to linked and monitoring processes.
- [x] ~~`CQueue`, taken from `distributed-process`, is quite complicated. We may want to make this pure STM.~~ (#11)
- [x] ~~Rework `CQueue`s "timeout" support using STM's `registerDelay`.~~ (#12)
- [x] Currently, there's `MonadProcess` which exposes some somewhat-high-level actions. However, these can be reimplemented by making `MonadProcess` more low-level. Basically, we'll want a way to retrieve the current `ProcessContext`, and some other `Maybe ProcessContext` based on a `ProcessId` (in STM). With those in place (and maybe some others), we can implement `sendWithOptions`, `spawnWithOptions` etc. outside of the class.
- [ ] Review/validate `spawnImpl`

Fixes: #25 