### PR TITLE
ci: fix install of `cabal-fmt`

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install cabal-fmt
         run: |
           cabal update
-          cabal install --with-ghc=ghc-9.4 "cabal-fmt-0.1.6"
+          cabal install --allow-newer=base "cabal-fmt-0.1.6"
 
       - name: checkout
         uses: actions/checkout@v3.3.0


### PR DESCRIPTION
Some new version of `cabal-install`, now used in CI, doesn't allow setting a compiler version on a specific package, but instead would need this to be set globally.

Instead of fixing the compiler to use, allow newer versions of `base` when installing `cabal-fmt` (currently restricted to `base <4.18`).