### PR TITLE
WIP: Add kindaUnlift to find out what happens where

### DIFF
--- a/troupe/src/Troupe.hs
+++ b/troupe/src/Troupe.hs
@@ -13,6 +13,7 @@ module Troupe
     spawn,
     spawnLink,
     spawnMonitor,
+    kindaUnlift,
 
     -- *** Spawning processes with options
     spawnWithOptions,
@@ -118,6 +119,7 @@ import Troupe.Process
     sendLazy,
     setProcessOption,
     spawnWithOptions,
+    kindaUnlift,
     unlink,
   )
 import Troupe.Types (Down (..), MonitorRef, ProcessId)


### PR DESCRIPTION
Works like this...

```haskell
server :: Troupe.Process NodeEnv ()
server = do
  serverPids <- (,) <$> myThreadId <*> Troupe.self
  traceShowM ("Server" :: Text, serverPids)

  Troupe.kindaUnlift \unlift ->
    liftIO $ Server.run config \connection ->
      -- The server does `forkIO` for each incoming connection
      unlift Troupe.Unbound do
        -- Unlift spawns a __new__ Process that has access to connection and server's process context
        handlerPids <- (,) <$> myThreadId <*> Troupe.self
        traceShowM ("Handler" :: Text, handlerPids)
```