### PR TITLE
ci: fix invocation of `cabal-fmt`

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Check formatting of Cabal project description
         run: |
-          ~/.cabal/bin/cabal-fmt --Werror --check troupe/troupe.cabal
+          cabal-fmt --Werror --check troupe/troupe.cabal


### PR DESCRIPTION
New versions of `cabal`, now installed in the GitHub CI runner environment, put binaries in `~/.local/bin` instead of `~/.cabal/bin`, hence, `cabal-fmt` could no longer be found where it was expected.